### PR TITLE
Added support for N. California Region (us-west-1)

### DIFF
--- a/doc_source/limits.md
+++ b/doc_source/limits.md
@@ -21,7 +21,7 @@ Following are the limits for Amazon EFS that can be increased by contacting AWS 
 | Resource | Default Limit | 
 | --- | --- | 
 | Number of file systems for each customer account in an AWS Region | 10 | 
-| Total throughput for each file system for all connected clients |  US East \(Ohio\) Region – 3 GB/s US East \(N\. Virginia\) Region – 3 GB/s US West \(Oregon\) Region – 3 GB/s EU \(Frankfurt\) Region – 1 GB/s EU \(Ireland\) Region – 3 GB/s Asia Pacific \(Sydney\) Region – 3 GB/s  | 
+| Total throughput for each file system for all connected clients |  US East \(Ohio\) Region – 3 GB/s US East \(N\. Virginia\) Region – 3 GB/s US West \(N\. California\) Region – 1 GB/s US West \(Oregon\) Region – 3 GB/s EU \(Frankfurt\) Region – 1 GB/s EU \(Ireland\) Region – 3 GB/s Asia Pacific \(Sydney\) Region – 3 GB/s  | 
 
 You can take the following steps to request an increase for these limits\. These increases are not granted immediately, so it might take a couple of days for your increase to become effective\.
 

--- a/doc_source/logging-using-cloudtrail.md
+++ b/doc_source/logging-using-cloudtrail.md
@@ -123,6 +123,7 @@ If you're using an encrypted file system, the calls that Amazon EFS makes on you
 | --- | --- | 
 | US East \(Ohio\) | 771736226457 | 
 | US East \(N\. Virginia\) | 055650462987 | 
+| US West \(N\. California\) | 208867197265 | 
 | US West \(Oregon\) | 736298361104 | 
 | EU \(Frankfurt\) | 992038834663 | 
 | EU \(Ireland\) | 805538244694 | 


### PR DESCRIPTION
Added total throughput limits for file systems in the N. California region. Added AWS-owned account ID that may appear in CloudTrail logs if using encrypted file systems in the N. California region.