### PR TITLE
Rectify instance type requirement

### DIFF
--- a/doc_source/walkthrough-file-sync-ec2.md
+++ b/doc_source/walkthrough-file-sync-ec2.md
@@ -34,7 +34,7 @@ To create a sync agent in Amazon EC2, you will use the AMI provided to create an
 **Note**  
 A sync agent syncs files to EFS file systems in the AWS region where the sync agent is activated\. Standard Amazon EC2 rates apply to the instance\.
 
-1. On the **Choose an Instance Type** page, choose the hardware configuration of your instance\. When deploying your sync agent on Amazon EC2,we recommend choosing one of the **Memory optimized r4\.xlarge** instance types for your sync agent\. The instance size you choose must be at least **xlarge**\.
+1. On the **Choose an Instance Type** page, choose the hardware configuration of your instance\. When deploying your sync agent on Amazon EC2,we recommend choosing one of the **Memory optimized** instance types for your sync agent\. The instance size you choose must be at least **xlarge**\.
 
 1. Choose **Next: Configure Instance Details**\.
 


### PR DESCRIPTION
It currently says to use "one of the Memory optimized r4.xlarge instance types", and later on it says to use at least xlarge. Changed that to say that customer should choose "one of the Memory optimized instance types", as it makes more sense.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
