### PR TITLE
Update on mount-fs-auto-mount-onreboot.md

### DIFF
--- a/doc_source/mount-fs-auto-mount-onreboot.md
+++ b/doc_source/mount-fs-auto-mount-onreboot.md
@@ -15,9 +15,16 @@ Before you can update the /etc/fstab file of your EC2 instance, make sure that y
 
 1. Add the following line to the `/etc/fstab` file\.
 
+**For File System witm amazon-efs-utils**
    ```
    fs-12345678 /mnt/efs efs defaults,_netdev 0 0
    ```
+   
+**For File System without amazon-efs-utils**
+   ```
+   fs-12345678 /mnt/efs nfs4 nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,_netdev 0 0
+   ```
+   
 **Warning**  
 Use the `_netdev` option, used to identify network file systems, when mounting your file system automatically\. If `_netdev` is missing, your EC2 instance might stop responding\. This result is because network file systems need to be initialized after the compute instance starts its networking\. For more information, see [Automatic Mounting Fails and the Instance Is Unresponsive](troubleshooting-efs-mounting.md#automount-fails)\.
 


### PR DESCRIPTION
As this first commit creating a branch for my fork to define an item that I am convinced that could create confusion and delay for AWS Customers.

On the current live document [1] the information on what to add into the file system tab "/etc/fstab"  is correct for customers that use EFS with encryption in transit or not. but some of the customers cannot or do not use the EFS mount helper [2]

In this cases, the old link [3] need to be considered as it still relevant information as some customers still use or can only use nfs-utils to mount the filesystem, please inspect my pool request to ensure this documentation can be revised and fixed.

Thanks for your time.

1 - https://docs.aws.amazon.com/efs/latest/ug/mount-fs-auto-mount-onreboot.html
2 - https://docs.aws.amazon.com/efs/latest/ug/using-amazon-efs-utils.html
3 - https://docs.aws.amazon.com/efs/latest/ug/mount-fs-auto-mount-onreboot-old.html

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
