### PR TITLE
Fix consistency in fstab rule

### DIFF
--- a/doc_source/mount-fs-auto-mount-onreboot.md
+++ b/doc_source/mount-fs-auto-mount-onreboot.md
@@ -16,7 +16,7 @@ Before you can update the /etc/fstab file of your EC2 instance, make sure that y
 1. Add the following line to the `/etc/fstab` file\.
 
    ```
-   fs-12345678 /mnt/efs efs defaults,_netdev 0 0
+   fs-12345678:/ /mnt/efs efs defaults,_netdev 0 0
    ```
 **Warning**  
 Use the `_netdev` option, used to identify network file systems, when mounting your file system automatically\. If `_netdev` is missing, your EC2 instance might stop responding\. This result is because network file systems need to be initialized after the compute instance starts its networking\. For more information, see [Automatic Mounting Fails and the Instance Is Unresponsive](troubleshooting-efs-mounting.md#automount-fails)\.


### PR DESCRIPTION
fstab entry example does not have `:/` whereas the table below does. Fixed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
