### PR TITLE
Remove sentence regarding on-demand mounting

### DIFF
--- a/doc_source/troubleshooting-efs-mounting.md
+++ b/doc_source/troubleshooting-efs-mounting.md
@@ -59,7 +59,7 @@ After you do so, run the following two commands:
 
 1. `sudo systemctl enable mount-nfs-sequentially.service`
 
-Then restart your Amazon EC2 instance\. The file systems are mounted on demand, generally within a second\.
+Then restart your Amazon EC2 instance\.
 
 ## Mount Command Fails with "wrong fs type" Error Message<a name="mount-error-wrong-fs"></a>
 


### PR DESCRIPTION
On "Mounting Multiple Amazon EFS File Systems in /etc/fstab Fails", there's a sentence which only applies when using noauto,x-systemd.automount mount options, so I removed it: "The file systems are mounted on demand, generally within a second".

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
