### PR TITLE
Fix typo. gi -> git

### DIFF
--- a/doc_source/using-amazon-efs-utils.md
+++ b/doc_source/using-amazon-efs-utils.md
@@ -63,7 +63,7 @@ If you don't want to get the amazon\-efs\-utils package from Amazon Linux or Ama
 
 1. Access the terminal for your instance through Secure Shell \(SSH\), and log in with the appropriate user name\. For more information on how to do this, see [Connecting to Your Linux Instance Using SSH](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AccessingInstancesLinux.html) in the *Amazon EC2 User Guide for Linux Instances\.*
 
-1. If you haven't done so already, install gi with the following command\.
+1. If you haven't done so already, install git with the following command\.
 
    ```
    sudo yum -y install git


### PR DESCRIPTION
Just fixing a small typo where you've put said "install gi" versus "install git"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
