### PR TITLE
Fixed Stunnel download link.

### DIFF
--- a/doc_source/using-amazon-efs-utils.md
+++ b/doc_source/using-amazon-efs-utils.md
@@ -152,7 +152,7 @@ After installing the Amazon EFS mount helper, you can upgrade your system's vers
 1. Replace *latest\-stunnel\-version* with the name of the file you noted previously in Step 2\.
 
    ```
-   $ sudo curl -o latest-stunnel-version.tar.gz https://www.stunnel.org/downloads.html/latest-stunnel-version.tar.gz
+   $ sudo curl -o latest-stunnel-version.tar.gz https://www.stunnel.org/downloads/latest-stunnel-version.tar.gz
    ```
 
 1. 


### PR DESCRIPTION


*Issue #, if available:*The current Stunnel download link does not download the tar gzip file.

*Description of changes:*
Changed the link to remove .html from the download url. 
Actual link : https://www.stunnel.org/downloads/stunnel-5.56.tar.gz

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
