### PR TITLE
Fix HTML numbering generated from Markdown

### DIFF
--- a/doc_source/using-amazon-efs-utils.md
+++ b/doc_source/using-amazon-efs-utils.md
@@ -143,8 +143,6 @@ After installing the Amazon EFS mount helper, you can upgrade your system's vers
 
 1. Open a terminal on your Linux client, and run the following commands in the order presented\.
 
-1. 
-
    ```
    $ sudo yum install -y gcc openssl-devel tcp_wrappers-devel
    ```
@@ -153,29 +151,9 @@ After installing the Amazon EFS mount helper, you can upgrade your system's vers
 
    ```
    $ sudo curl -o latest-stunnel-version.tar.gz https://www.stunnel.org/downloads.html/latest-stunnel-version.tar.gz
-   ```
-
-1. 
-
-   ```
    $ sudo tar xvfz latest-stunnel-version.tar.gz
-   ```
-
-1. 
-
-   ```
    $ cd latest-stunnel-version/
-   ```
-
-1. 
-
-   ```
    $ sudo ./configure
-   ```
-
-1. 
-
-   ```
    $ sudo make
    ```
 
@@ -185,27 +163,23 @@ After installing the Amazon EFS mount helper, you can upgrade your system's vers
    $ sudo rm /bin/stunnel
    ```
 
-1. 
+1. Install the new version\.
 
    ```
    $ sudo make install
    ```
 
-1. 
-**Note**  
-The default CentOS shell is csh, which has different syntax than the bash shell\. The following code first invokes bash, then runs\.
+1. **Note**  
+   The default CentOS shell is csh, which has different syntax than the bash shell\. The following code first invokes bash, then runs\.
 
    ```
-   bash
+   % bash
+   $ if [[ -f /bin/stunnel ]]; then
+   > sudo mv /bin/stunnel /root
+   > fi
    ```
 
-   ```
-   if [[ -f /bin/stunnel ]]; then
-   sudo mv /bin/stunnel /root
-   fi
-   ```
-
-1. 
+1. Link the new version\.
 
    ```
    $ sudo ln -s /usr/local/bin/stunnel /bin/stunnel


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* A few small changes to fix numbering. In two cases I needed to add some copy so that numbers had content after them; "Install the new version" and "Link the new version". For the note about csh I added a csh prompt ("%") and continuation prompts (">") to be consistent with showing prompts for all other commands.

**before:**
![efs_docs_before](https://user-images.githubusercontent.com/708421/81919466-30a7cf80-95d8-11ea-96a2-cbf1a50636f8.png)

**after:**
![efs_docs_after](https://user-images.githubusercontent.com/708421/81919494-38677400-95d8-11ea-9128-e323734ab5dc.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
