### PR TITLE
CLI --encrypted flag doesn't take parameter

### DIFF
--- a/doc_source/wt1-create-efs-resources.md
+++ b/doc_source/wt1-create-efs-resources.md
@@ -21,7 +21,7 @@ In this step, you create an Amazon EFS file system\. Write down the `FileSystemI
 
      ```
      $  aws efs create-file-system \
-     --encrypted true \
+     --encrypted \
      --creation-token FileSystemForWalkthrough1 \
      --tags Key=Name,Value=SomeExampleNameValue \
      --region us-west-2 \


### PR DESCRIPTION
it's `--encrypted` or `--no-encrypted`, not `--encrypted true` or `--encrypted false`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
