### PR TITLE
fix: replace smart quotes in policy example

### DIFF
--- a/doc_source/enable-root-squashing.md
+++ b/doc_source/enable-root-squashing.md
@@ -36,12 +36,12 @@ Clients that aren't anonymous can get root access to the file system through an 
 
    ```
    {
-       “Version”: “2012-10-17”,
-       “Statement”: [
+       "Version": "2012-10-17",
+       "Statement": [
            {
-           “Resource”: “*”,
-           “Effect”: “Allow”,
-           “Action”: “elasticfilesystem:Client*”
+           "Resource": "*",
+           "Effect": "Allow",
+           "Action": "elasticfilesystem:Client*"
            }
        ],
        "Condition": {}


### PR DESCRIPTION
policy JSON had smart quotes - replaces with " character

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
