### PR TITLE
Making the instructions more robust.

### DIFF
--- a/doc_source/upgrading-stunnel.md
+++ b/doc_source/upgrading-stunnel.md
@@ -23,6 +23,8 @@ After installing the Amazon EFS mount helper, you can upgrade your system's vers
    ```
    sudo curl -o latest-stunnel-version.tar.gz https://www.stunnel.org/downloads/latest-stunnel-version.tar.gz
    ```
+**Warning**
+Verify the signature on this file before proceeding by using the gpg key with fingerprint `AC91 5EA3 0645 D9D3 D4DA  E4FE B104 8932 DD3A AAA3`. For an example of how to do this, see [this link](https://docs.aws.amazon.com/systems-manager/latest/userguide/verify-agent-signature.html).
 
 1. 
 


### PR DESCRIPTION
The user should be instructed to verify the signature on the tarball before using it.

*Issue #, if available:*

*Description of changes:* 

[These instructions](https://docs.aws.amazon.com/efs/latest/ug/upgrading-stunnel.html) should include a step for verifying the signature on the tarball so that the risk of supply chain attack is mitigated.

I included the fingerprint of the current key found here: https://www.stunnel.org/downloads.html

The link takes the user to another page in the awsdocs that shows how to verify the signature on the tarball.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
