### PR TITLE
Update troubleshooting-efs-mounting.md

### DIFF
--- a/doc_source/troubleshooting-efs-mounting.md
+++ b/doc_source/troubleshooting-efs-mounting.md
@@ -108,9 +108,6 @@ $ grep CONFIG_NFS_V4_1 /boot/config*
 
 If the preceding command returns `# CONFIG_NFS_V4_1 is not set`, NFSv4\.1 is not supported on your Linux distribution\. For a list of the Amazon Machine Images \(AMIs\) for Amazon Elastic Compute Cloud \(Amazon EC2\) that support NFSv4\.1, see [NFS support](mounting-fs-old.md#mounting-fs-nfs-info)\. 
 
-**Action to take**  
-If you receive this message, install the `nfs-utils` \(or `nfs-common` on Ubuntu\) package\. For more information, see [Installing the NFS client](mounting-fs-old.md#mounting-fs-install-nfsclient)\.
-
 ## Mount Command Fails with "No such file or directory" Error Message<a name="mount-error-no-such-file-or-directory"></a>
 
 The mount command fails with the following error message\.

--- a/doc_source/troubleshooting-efs-mounting.md
+++ b/doc_source/troubleshooting-efs-mounting.md
@@ -7,6 +7,7 @@
 + [Mounting Multiple Amazon EFS File Systems in /etc/fstab Fails](#automount-fix-multiple-fs)
 + [Mount Command Fails with "wrong fs type" Error Message](#mount-error-wrong-fs)
 + [Mount Command Fails with "incorrect mount option" Error Message](#mount-error-incorrect-mount)
++ [Mount Command Fails with "No such file or directory" Error Message](#mount-error-no-such-file-or-directory)
 + [File System Mount Fails Immediately After File System Creation](#mount-fails-propegation)
 + [File System Mount Hangs and Then Fails with Timeout Error](#mount-hangs-fails-timeout)
 + [File System Mount Using DNS Name Fails](#mount-fails-dns-name)
@@ -106,6 +107,20 @@ $ grep CONFIG_NFS_V4_1 /boot/config*
 ```
 
 If the preceding command returns `# CONFIG_NFS_V4_1 is not set`, NFSv4\.1 is not supported on your Linux distribution\. For a list of the Amazon Machine Images \(AMIs\) for Amazon Elastic Compute Cloud \(Amazon EC2\) that support NFSv4\.1, see [NFS support](mounting-fs-old.md#mounting-fs-nfs-info)\. 
+
+**Action to take**  
+If you receive this message, install the `nfs-utils` \(or `nfs-common` on Ubuntu\) package\. For more information, see [Installing the NFS client](mounting-fs-old.md#mounting-fs-install-nfsclient)\.
+
+## Mount Command Fails with "No such file or directory" Error Message<a name="mount-error-no-such-file-or-directory"></a>
+
+The mount command fails with the following error message\.
+
+```
+mount.nfs4: mounting <access_point> failed, reason given by server: No such file or directory
+```
+
+**Action to take**  
+This error message most likely means that the specified EFS path does not exist.  Note that while the AWS Console to create an EFS access point does explicitly state that the specified EFS folder will be created if it does not already exist, this does not actually happen.  You must manually create the folder in the EFS file system.
 
 ## File System Mount Fails Immediately After File System Creation<a name="mount-fails-propegation"></a>
 


### PR DESCRIPTION
*Issue #, if available:*

n/a, just wanted to save some other poor soul some time if they hit the same problem

*Description of changes:*

Added section for error message that happens when the EFS file system does not have the specified path.  Note that the AWS Create Access Point page is flat-out wrong when it says that it will create that folder for you.  I just spent half a day troubleshooting this issue, until I finally thought to look at the EFS file system contents despite the promise that the folder would be there.  Someone else on my team mentioned having this exact same problem a few months ago (but of course he didn't remember this until after I figured it out).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
