### PR TITLE
Update stray "master" branch references to "main"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,13 +25,13 @@ We look forward to receiving your pull requests for:
 To contribute, send us a pull request. For small changes, such as fixing a typo or adding a link, you can use the [GitHub Edit Button](https://blog.github.com/2011-04-26-forking-with-the-edit-button/). For larger changes:
 
 1. [Fork the repository](https://help.github.com/articles/fork-a-repo/).
-2. In your fork, make your change in a branch that's based on this repo's **master** branch.
+2. In your fork, make your change in a branch that's based on this repo's **main** branch.
 3. Commit the change to your fork, using a clear and descriptive commit message.
 4. [Create a pull request](https://help.github.com/articles/creating-a-pull-request-from-a-fork/), answering any questions in the pull request form.
 
 Before you send us a pull request, please be sure that:
 
-1. You're working from the latest source on the **master** branch.
+1. You're working from the latest source on the **main** branch.
 2. You check [existing open](https://github.com/awsdocs/amazon-efs-user-guide/pulls), and [recently closed](https://github.com/awsdocs/amazon-efs-user-guide/pulls?q=is%3Apr+is%3Aclosed), pull requests to be sure that someone else hasn't already addressed the problem.
 3. You [create an issue](https://github.com/awsdocs/amazon-efs-user-guide/issues/new) before working on a contribution that will take a significant amount of your time.
 
@@ -53,4 +53,4 @@ If you discover a potential security issue, please notify AWS Security via our [
 
 ## Licensing
 
-See the [LICENSE](https://github.com/awsdocs/amazon-efs-user-guide/blob/master/LICENSE) file for this project's licensing. We will ask you to confirm the licensing of your contribution. We may ask you to sign a [Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) for larger changes.
+See the [LICENSE](https://github.com/awsdocs/amazon-efs-user-guide/blob/main/LICENSE) file for this project's licensing. We will ask you to confirm the licensing of your contribution. We may ask you to sign a [Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) for larger changes.

--- a/doc_source/mounting-fs-mount-cmd-ip-addr.md
+++ b/doc_source/mounting-fs-mount-cmd-ip-addr.md
@@ -36,4 +36,4 @@ You must use `mountport=2049` in order to succesfully connect to the EFS file sy
 
 ## Mounting with an IP address in AWS CloudFormation<a name="mount-fs-ip-addr-cloudformation"></a>
 
-You can also mount your file system using an IP address in an AWS CloudFormation template\. For more information, see [storage\-efs\-mountfilesystem\-ip\-addr\.config](https://github.com/awsdocs/elastic-beanstalk-samples/blob/master/configuration-files/community-provided/instance-configuration/storage-efs-mountfilesystem-ip-addr.config) in the **awsdocs/elastic\-beanstalk\-samples** repository for community\-provided configuration files on GitHub\.
+You can also mount your file system using an IP address in an AWS CloudFormation template\. For more information, see [storage\-efs\-mountfilesystem\-ip\-addr\.config](https://github.com/awsdocs/elastic-beanstalk-samples/blob/main/configuration-files/community-provided/instance-configuration/storage-efs-mountfilesystem-ip-addr.config) in the **awsdocs/elastic\-beanstalk\-samples** repository for community\-provided configuration files on GitHub\.


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
Update of stray references to "master" as the default branch, to "main":  user-facing references and "master" links to (this and) other repositories where "main" is now the default.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
