### PR TITLE
Match listen port range for stunnel to efs-utils

### DIFF
--- a/doc_source/encryption-in-transit.md
+++ b/doc_source/encryption-in-transit.md
@@ -32,7 +32,7 @@ If you're not using the mount helper, you can still enable encryption of data in
 
 1. Using the NFS client, mount `localhost:port`, where `port` is the port that you noted in the first step\.
 
-Because encryption of data in transit is configured on a per\-connection basis, each configured mount has a dedicated stunnel process running on the instance\. By default, the stunnel process used by the mount helper listens on local ports 20049 and 20449, and it connects to Amazon EFS on port 2049\.
+Because encryption of data in transit is configured on a per\-connection basis, each configured mount has a dedicated stunnel process running on the instance\. By default, the stunnel process used by the mount helper listens on a local port ranging from 20049 through 21048, and it connects to Amazon EFS on port 2049\.
 
 **Note**  
 By default, when using the Amazon EFS mount helper with TLS, the mount helper enforces certificate hostname checking\. The Amazon EFS mount helper uses the stunnel program for its TLS functionality\. Some versions of Linux don't include a version of stunnel that supports these TLS features by default\. When using one of those Linux versions, mounting an Amazon EFS file system using TLS fails\.  


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
Match the documented range of ports from which a listening port is selected for stunnel, to the actual range currently defined in [aws/efs-utils](https://github.com/aws/efs-utils)--specifically, the top value.

I did consider suggesting the range be changed in [aws/efs-utils](https://github.com/aws/efs-utils) so that 21049 is included (i.e. bump the upper bound by one), and so indirectly fix any broader mention of 21049 being in the range, but I'd guess more people are familiar with blocks of ports being described inclusively, and 'fixing' a neat block of 1000 ports by adding one ...

[aws/efs-utils/dist/efs-utils.conf](https://github.com/aws/efs-utils/blob/d504305340e54c4e82723530ae038c6ff6a3dfd5/dist/efs-utils.conf#L35)
> ```
> 35  # Define the port range that the TLS tunnel will choose from
> 36  port_range_lower_bound = 20049
> 37  port_range_upper_bound = 21049
> ```

[aws/efs-utils/src/mount_efs/\_\_init\_\_.py](https://github.com/aws/efs-utils/blob/d504305340e54c4e82723530ae038c6ff6a3dfd5/src/mount_efs/__init__.py#L946)
> ```python
> 946        lower_bound, upper_bound = get_tls_port_range(config)
> 947
> 948        ports_to_try = list(range(lower_bound, upper_bound))
> ```

(thanks @amh-mw for [tracking down the ports in efs-utils](https://github.com/hashicorp/terraform-provider-aws/issues/19549#issuecomment-1261242741))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.