### PR TITLE
Clarify EC2 EFS mount command usage in walkthrough

### DIFF
--- a/doc_source/wt1-test.md
+++ b/doc_source/wt1-test.md
@@ -71,13 +71,13 @@ Now you mount the file system on your EC2 instance\.
    $ mkdir ~/efs-mount-point 
    ```
 
-1. Mount the Amazon EFS file system\. 
+1. Mount the Amazon EFS file system using the DNS name of the EFS file system\.
 
    ```
    $ sudo mount -t nfs -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport mount-target-DNS:/   ~/efs-mount-point  
    ```
 
-   The EC2 instance can resolve the mount target DNS name to the IP address\. You can optionally specify the IP address of the mount target directly\.
+   If the EC2 instance cannot resolve the EFS file system DNS name to the underlying IP address, you can specify the IP address of the mount target directly\.
 
    ```
    $ sudo mount -t nfs -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport mount-target-ip:/  ~/efs-mount-point


### PR DESCRIPTION
*Description of changes:*
Clarify the usage of the `mount` command when mounting the EFS from your EC2 machine, as outlined in
Step 3.3.2: https://docs.aws.amazon.com/efs/latest/ug/wt1-test.html#wt1-mount-fs-and-test

In particular, this pull request aims to clarify when the optional usage of the EFS mount target IP should be used. In other words:
- if your EC2 machine can resolve the EFS file system DNS name, then use the DNS name in the mount command.
- If your EC2 machine cannot resolve the EFS file system DNS name, then you can specify the mount target IP address.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
